### PR TITLE
Add required ec2:DescribeLaunchTemplateVersions action to the policy

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -16,7 +16,8 @@ resource "aws_iam_policy" "cluster_autoscaler" {
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeTags",
         "autoscaling:SetDesiredCapacity",
-        "autoscaling:TerminateInstanceInAutoScalingGroup"
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "ec2:DescribeLaunchTemplateVersions"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
It's required for eks according to the docs: https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html